### PR TITLE
Align plugin language metadata with available locale files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ No external services. No cron jobs. No extra dependencies beyond GLPI itself.
 | **Cooldown protection** | 30-second cooldown after each send prevents accidental duplicate blasts from concurrent browser tabs |
 | **Duplicate recipient guard** | Within-batch deduplication skips users sharing an email address so no recipient receives the same message twice |
 | **Send history** | Last 10 mass sends stored and displayed on the configuration page (date, subject, sent count, failed count) with server-timezone timestamps |
-| **Full i18n** | `es_MX`, `fr_FR`, `de_DE` |
+| **Full i18n** | Base language: `en` (without dedicated `.po/.mo`); translations: `es_MX`, `fr_FR`, `de_DE` |
 
 ---
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -28,7 +28,7 @@ Send a bulk email to every active GLPI user that has a default email address reg
 - **Test send** — send to your own admin address or any specific address before the mass mailing
 - **Form persistence** — subject and footer saved automatically and restored on next visit
 - **Dark/light mode** — fully theme-aware
-- **Fully localized** — es_MX, en_US, en_GB, fr_FR, de_DE
+- **Fully localized** — en (base), es_MX, fr_FR, de_DE
          </en>
          <es_MX>
 ## Mail Blast
@@ -46,7 +46,7 @@ Envía un correo masivo a todos los usuarios activos de GLPI que tengan una dire
 - **Correo de prueba** — envía a tu dirección de administrador o a una dirección específica antes del envío masivo
 - **Persistencia del formulario** — asunto y pie guardados automáticamente y restaurados en la siguiente visita
 - **Modo oscuro/claro** — compatible con ambos temas de GLPI
-- **Completamente localizado** — es_MX, en_US, en_GB, fr_FR, de_DE
+- **Completamente localizado** — en (base), es_MX, fr_FR, de_DE
          </es_MX>
       </long>
    </description>
@@ -71,8 +71,6 @@ Envía un correo masivo a todos los usuarios activos de GLPI que tengan una dire
    </versions>
    <langs>
       <lang>es_MX</lang>
-      <lang>en_US</lang>
-      <lang>en_GB</lang>
       <lang>fr_FR</lang>
       <lang>de_DE</lang>
    </langs>


### PR DESCRIPTION
### Motivation
- The `<langs>` metadata in `plugin.xml` listed `en_US` and `en_GB` while the `locales/` folder only contains `es_MX`, `fr_FR`, and `de_DE`, which could confuse users and release tooling. 
- English is intended to be the base language without dedicated `.po/.mo` catalogs, so the metadata and docs should reflect that.

### Description
- Removed `<lang>en_US</lang>` and `<lang>en_GB</lang>` from the `<langs>` block in `plugin.xml` so entries match the actual locale files. 
- Updated the localization bullets in `plugin.xml` (English and Spanish long descriptions) to state English as `en (base)` instead of listing `en_US`/`en_GB`. 
- Updated the `README.md` i18n feature row to document that the base language is `en` (no dedicated `.po/.mo`) and that translations are `es_MX`, `fr_FR`, and `de_DE`.

### Testing
- Ran `ls locales` to list available locale files and confirmed `de_DE`, `es_MX`, and `fr_FR` catalogs are present. 
- Extracted the `<langs>` block from `plugin.xml` with `sed` and verified it now contains only `es_MX`, `fr_FR`, and `de_DE`. 
- Executed a Python consistency check that compares `locales/*.po` names against the `<lang>` entries and it reported no missing or extra locales. 
- All automated checks above succeeded.

------